### PR TITLE
fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module svb
+module github.com/rleiwang/svb
 
 go 1.14
 


### PR DESCRIPTION
```
$ go get github.com/rleiwang/svb
go: downloading github.com/rleiwang/svb v0.0.0-20200523015304-c272219405dc
go: github.com/rleiwang/svb@v0.0.0-20200523015304-c272219405dc: parsing go.mod:
        module declares its path as: svb
                but was required as: github.com/rleiwang/svb
```

This fixes that by updating the go.mod file